### PR TITLE
Disable tern

### DIFF
--- a/.emacs.d/inits/12-javascript.el
+++ b/.emacs.d/inits/12-javascript.el
@@ -1,18 +1,5 @@
 (el-get-bundle js2-mode)
-(el-get-bundle tern)
-(el-get-bundle tern-auto-complete)
 (add-to-list 'auto-mode-alist '("\\.js\\'" . js2-mode))
-
-(eval-after-load 'tern
-  '(progn
-    (require 'tern-auto-complete)
-    (tern-ac-setup)))
-
-
-
-(add-hook 'js2-mode-hook
-    (lambda ()
-      (tern-mode t)))
 
 (custom-set-variables
 
@@ -25,3 +12,20 @@
  '(js2-strict-missing-semi-warning nil)
 
  )
+
+;;tern strongly requires node so currently disabled
+
+;;(el-get-bundle tern)
+;;(el-get-bundle tern-auto-complete)
+
+;;(eval-after-load 'tern
+;;  '(progn
+;;    (require 'tern-auto-complete)
+;;    (tern-ac-setup)))
+
+
+
+;;(add-hook 'js2-mode-hook
+;;    (lambda ()
+;;      (tern-mode t)))
+


### PR DESCRIPTION
With tern, Emacs tries to retrieve node on startup.
To re-enable, revert this PR.